### PR TITLE
updates to run github react build instead of on server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Build and Publish
+
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types:
+      - completed
+    branches:
+      - main
+
+jobs:
+  build-and-push:
+    # Only run if tests succeeded AND the commit wasn't from the bot (prevents infinite loop)
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_commit.author.name != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build React app
+        run: npm run build
+
+      - name: Commit and push build to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add build/
+          git diff --cached --quiet && echo "No changes to build output, skipping commit." && exit 0
+          git commit -m "ci: build from main @ ${{ github.event.workflow_run.head_sha }}"
+          git push origin main

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# deploy.sh — Run this on the EC2 instance to pull the latest build and restart the server.
+# Usage: chmod +x deploy.sh && ./deploy.sh
+set -euo pipefail
+
+# EDIT: absolute path to the project directory on the EC2 instance
+REPO_DIR="/path/to/your/app"
+BRANCH="main"
+
+echo "[deploy] Pulling latest from ${BRANCH}..."
+cd "$REPO_DIR"
+
+git fetch origin "$BRANCH"
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse "origin/${BRANCH}")
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  echo "[deploy] Already up to date. Nothing to do."
+  exit 0
+fi
+
+git pull origin "$BRANCH"
+echo "[deploy] Updated to $(git rev-parse --short HEAD)"
+
+# Uncomment whichever process manager runs your server:
+
+# Option A: PM2 (run `pm2 list` to find your process name)
+# pm2 restart personalsite
+
+# Option B: systemd (run `systemctl list-units --type=service | grep node` to find your service name)
+# sudo systemctl restart personalsite
+
+echo "[deploy] Done."
+
+# Optional: add to cron to poll every 5 minutes automatically:
+#   crontab -e
+#   */5 * * * * /path/to/deploy.sh >> /home/ubuntu/deploy.log 2>&1


### PR DESCRIPTION
# Deployment Guide

This document explains the CI/CD infrastructure added to this project, how each piece works, and exactly what you need to do for the first deployment and for every PR merge going forward.

---

## The Problem This Solves

The EC2 server running the site does not have enough memory to run `npm run build`. That command compiles the React frontend into a `/build` folder of optimized static HTML, CSS, and JavaScript. Previously the workaround was building locally and committing the `/build` folder to a branch, then pulling it on the server manually.

The new setup moves the build step to GitHub's infrastructure (free, unlimited memory) and automates the whole process so you never have to think about it again.

---

## What Was Added

Two files were created:

- **`.github/workflows/build.yml`** — a GitHub Actions workflow that runs in the cloud after your tests pass
- **`deploy.sh`** — a shell script you place on the EC2 server to pull down the new build and restart Node

Nothing in `package.json` or `server.js` needs to change. The server already knows how to serve the `/build` folder — we are just automating who puts it there.

---

## How `build.yml` Works (Step by Step)

This file lives in `.github/workflows/` which tells GitHub to treat it as an automated workflow. GitHub reads it and runs it on their servers in response to events you define.

### The Trigger

```yaml
on:
  workflow_run:
    workflows: ["Tests"]
    types:
      - completed
    branches:
      - main
```

This says: "Run this workflow whenever the workflow named `Tests` finishes on the `main` branch." The `Tests` workflow is your existing `test.yml` file — its `name:` field at the top is literally `Tests`, and that string must match exactly here.

The `workflow_run` trigger is used instead of a direct push trigger because we want to run tests *before* building. If tests fail, there is no point in building a broken app. This creates a chain: push to main → tests run → if tests pass → build runs.

### The Guard Against Infinite Loops

```yaml
if: |
  github.event.workflow_run.conclusion == 'success' &&
  github.event.workflow_run.head_commit.author.name != 'github-actions[bot]'
```

There are two conditions here, both of which must be true:

1. **`conclusion == 'success'`** — The tests actually passed. If they failed, the build is skipped entirely.
2. **`author.name != 'github-actions[bot]'`** — The commit that triggered the tests was NOT made by the bot itself.

The second condition is critical. Here is why: when the build workflow runs, it commits the `/build` folder back to `main` and pushes. That push to `main` triggers `Tests` again. `Tests` passing would then trigger `Build and Publish` again — an infinite loop. The guard breaks this cycle by detecting that the triggering commit came from `github-actions[bot]` (the identity the workflow uses when it commits) and skipping the build in that case.

### The Build Steps

```yaml
- name: Checkout main
  uses: actions/checkout@v4
  with:
    ref: main
```

GitHub checks out a fresh copy of your `main` branch onto a temporary Ubuntu virtual machine. This VM has plenty of memory and CPU — it is a full cloud runner, not your EC2 instance.

```yaml
- name: Install dependencies
  run: npm ci
```

Installs all npm packages from `package-lock.json`. `npm ci` is used instead of `npm install` because it is faster (no lockfile resolution) and deterministic (always installs exactly what is in the lockfile, no version drift).

```yaml
- name: Build React app
  run: npm run build
```

Runs `react-scripts build`, which compiles all your React source code into the `/build` folder. This is the step that was too memory-intensive for the EC2 server. On GitHub's runner, it completes without issue.

```yaml
- name: Commit and push build to main
  run: |
    git config user.name "github-actions[bot]"
    git config user.email "github-actions[bot]@users.noreply.github.com"
    git add build/
    git diff --cached --quiet && echo "No changes to build output, skipping commit." && exit 0
    git commit -m "ci: build from main @ ${{ github.event.workflow_run.head_sha }}"
    git push origin main
```

After the build completes, the workflow commits the `/build` folder back to `main` and pushes it. A few things to note:

- **`git add build/`** — Only the build folder is staged. Nothing else in the working directory is touched.
- **`git diff --cached --quiet && ... exit 0`** — This is an idempotency check. If the source code change did not actually affect the compiled output (for example, a README edit), the build output will be byte-for-byte identical to what is already committed. In that case, there is nothing to commit and the workflow exits cleanly without pushing an empty commit.
- **The commit message** embeds the SHA of the source commit that triggered the build (`head_sha`). This means you can always look at a build commit on `main` and trace it back to the exact source code that produced it.
- **Authentication** — The push uses the automatic `GITHUB_TOKEN` that GitHub injects into every workflow. No personal access token or SSH key is needed. You do need to ensure the repository allows workflows to write (covered in the setup steps below).

---

## How `deploy.sh` Works

This script lives in the project root as a reference. You copy it to the EC2 server, edit one line, and run it whenever you want to pull in a new build.

```bash
REPO_DIR="/path/to/your/app"
BRANCH="main"
```

Set `REPO_DIR` to the absolute path of the project on the EC2 instance. `BRANCH` is `main` — the server now pulls directly from main, which always contains the latest committed build.

```bash
git fetch origin "$BRANCH"
LOCAL=$(git rev-parse HEAD)
REMOTE=$(git rev-parse "origin/${BRANCH}")

if [ "$LOCAL" = "$REMOTE" ]; then
  echo "[deploy] Already up to date. Nothing to do."
  exit 0
fi
```

This checks whether the remote has any new commits before pulling. If you run the script and nothing has changed since the last deploy, it exits without doing anything. This makes the script safe to run repeatedly or on a cron schedule.

```bash
git pull origin "$BRANCH"
```

Pulls the new commits — including the build commit that GitHub Actions pushed — down to the EC2 instance. The `/build` folder is now updated on the server.

```bash
# pm2 restart personalsite
# sudo systemctl restart personalsite
```

One of these lines needs to be uncommented to restart the Node process after the pull. The server must restart so it picks up any server-side changes (like new API routes in `src/api/`). For the static React files alone, a restart is not strictly required since Express serves them directly from disk on each request, but it is good practice and ensures any server-side code changes take effect immediately.

---

## Does Anything in `package.json` Need to Change?

**No.** The `package.json` scripts are unchanged. The server on EC2 runs `npm run prod`, which is `NODE_ENV=production node server.js`. That command just starts Express, which serves the `/build` folder as static files. It does not build anything. The build now happens in GitHub Actions before the files ever reach the server.

---

## Should You Delete the `/build` Folder on the Server?

**No, do not delete it.** The server needs the `/build` folder present to serve the site. `git pull` will replace the contents of `/build` with whatever GitHub Actions compiled, so the old build is automatically overwritten — you do not need to clear it manually.

If for some reason you wanted to start completely fresh (e.g., the folder is corrupted), you could `rm -rf build/` and then `git pull` to restore it from the remote. But under normal operation there is no reason to do this.

---

## One-Time Setup

### 1. Enable Workflow Write Permissions on GitHub

The build workflow pushes a commit back to `main`, which requires write access. By default, some repositories restrict this.

Go to: **GitHub repo → Settings → Actions → General → Workflow permissions**

Set it to: **"Read and write permissions"**

Save. You only do this once.

### 2. Confirm `build/` Is Not in `.gitignore` on `main`

Run this in the project root:

```bash
git check-ignore -v build/
```

If it prints nothing, you are fine — the folder is not ignored and can be committed. If it prints a `.gitignore` match, you will need to remove that line from `.gitignore` on `main`.

### 3. Set Up `deploy.sh` on the EC2 Server

Copy the `deploy.sh` file from the project root to your EC2 instance (or just create it there directly). Edit the `REPO_DIR` variable to the actual path. Uncomment the correct restart command for your process manager. Make it executable:

```bash
chmod +x ~/deploy.sh
```

To figure out which process manager is running the server:

```bash
pm2 list
# or
systemctl list-units --type=service | grep -i node
```

---

## Your First Deploy After This Setup

The first deploy after merging this infrastructure change works like this:

1. **Merge your PR** (which includes `build.yml` and `deploy.sh`) into `main`
2. **Watch the Actions tab** on GitHub. You will see two workflows run in sequence:
   - `Tests` runs first (triggered by the push to main)
   - `Build and Publish` runs after tests pass
3. **After `Build and Publish` completes**, look at the `main` branch on GitHub. You will see a new commit from `github-actions[bot]` with a message like `ci: build from main @ abc1234`
4. **On the EC2 server**, run:
   ```bash
   ~/deploy.sh
   ```
   It will pull the new build commit and restart the server.
5. **Visit the site** to confirm it is live.

That is the full first deploy. After this, the process is mostly automatic — you just run `deploy.sh` on the server after each merge.

---

## Normal Workflow After Every PR Merge

Once everything is set up, the workflow for every future change is:

1. **Develop on a feature branch**, open a PR
2. **Merge the PR into `main`** on GitHub (or locally and push)
3. **GitHub runs `Tests` automatically** — you can watch this in the Actions tab
4. **If tests pass, `Build and Publish` runs automatically** — GitHub builds the React app and pushes the `/build` folder to `main`
5. **SSH into the EC2 server and run `~/deploy.sh`** — this pulls the new build and restarts the server

Steps 3 and 4 are fully automatic. The only manual step on the server side is running `deploy.sh` (step 5).

### Optional: Automate Step 5 with a Cron Job

If you want the server to check for new builds automatically, add this to cron on the EC2 instance:

```bash
crontab -e
```

Add this line (checks every 5 minutes):

```
*/5 * * * * /home/ubuntu/deploy.sh >> /home/ubuntu/deploy.log 2>&1
```

With this in place, the server will automatically detect and apply new builds within 5 minutes of a merge. You would not need to SSH in at all for routine deploys. The script is safe to run on a schedule — it does nothing if there is no new build.

---

## Summary of the Full Pipeline

```
You push code / merge PR
        ↓
GitHub triggers "Tests" workflow (test.yml)
        ↓
Tests pass
        ↓
GitHub triggers "Build and Publish" workflow (build.yml)
        ↓
GitHub runner installs deps and builds React app
        ↓
Build committed to main by github-actions[bot]
        ↓
EC2 server runs deploy.sh (manually or via cron)
        ↓
Server pulls new build from main
        ↓
Server restarts — site is live with new code
```
